### PR TITLE
correct mistakes in readme, and clarify more about needed pl version, import usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,24 @@ To install: `pip install rtutils`
 Note that: some functions are designed to only work for me and my machines. But those that are useful, I make them as general as possible.
 ## Stateless resume from checkpoint saved in the middle of one epoch
 
-The change is essencially one line.
+The change is essencially one line for import and one line for use.
 
+Import function implemented in our repo:
+```
+import rtutils.pl_patch
+```
+
+Use the function imported to modify the pytorch_lightning trainer:
 ```
 trainer = pl.Trainer(...)
 # after defining the trainer
-trainer.pl_patch.patch_everything(trainer)
+rtutils.pl_patch.patch_everything(trainer)
 ```
 
 And, see the file examples/pl_deterministic_sampler.py to see what other changes need to made. 
 
 Some requirements:
+- pytorch_lightning version: >= 1.4.0 for rtutils >= 0.3; pytorch_lightning version: >=1.3 and < 1.4 for rtutils < 0.3
 - Using ModelCheckpoint
 - Using ddp training
 - replace_ddp_sampler is True (default to be True); and you are not manually setting any train loader sampler.


### PR DESCRIPTION
correct mistakes in readme, include:
1) the import method, by "import rtutils.pl_patch"
2) the version of pytorch_lightning needed is tested and clarified
3) the possible spelling mistake of function usage (trainer.pl_patch -> rtutils.pl_patch) to modify the trainer is corrected